### PR TITLE
support component names when they are created as ES6 classes

### DIFF
--- a/src/lib/createContainer.js
+++ b/src/lib/createContainer.js
@@ -15,7 +15,7 @@ module.exports = function (Component, options) {
 	options = arguments[1] || {};
 
 	var Container = React.createClass({
-		displayName: Component.displayName + "Container",
+		displayName: (Component.displayName || Component.name) + "Container",
 		propTypes: {
 			queryParams: React.PropTypes.object,
 			onQuery:     React.PropTypes.func,


### PR DESCRIPTION
@mikekreeki this fixes the 'undefinedContainer' transmit container name which harms performance analysis a lot.
